### PR TITLE
Remove path validation from callee

### DIFF
--- a/src/funnels/callees/SwapperCalleeUniV3.sol
+++ b/src/funnels/callees/SwapperCalleeUniV3.sol
@@ -42,20 +42,10 @@ contract SwapperCalleeUniV3 {
         uniV3Router = _uniV3Router;
     }
 
-    function swapCallback(address src, address dst, uint256 amt, uint256 minOut, address to, bytes calldata data) external {
-        bytes memory path = data;
-
-        address firstToken;
-        address lastToken;
-        assembly {
-            firstToken := div(mload(add(path, 0x20)), 0x1000000000000000000000000)
-            lastToken := div(mload(sub(add(add(path, 0x20), mload(path)), 0x14)), 0x1000000000000000000000000)
-        }
-        require(src == firstToken && dst == lastToken, "SwapperCalleeUniV3/invalid-path");
-
+    function swapCallback(address src, address /* dst */, uint256 amt, uint256 minOut, address to, bytes calldata data) external {
         ApproveLike(src).approve(uniV3Router, amt);
         SwapRouterLike.ExactInputParams memory params = SwapRouterLike.ExactInputParams({
-            path:             path,
+            path:             data,
             recipient:        to,
             deadline:         block.timestamp,
             amountIn:         amt,

--- a/test/funnels/callees/SwapperCalleeUniV3.t.sol
+++ b/test/funnels/callees/SwapperCalleeUniV3.t.sol
@@ -57,11 +57,4 @@ contract SwapperCalleeUniV3Test is DssTest {
         bytes memory USDC_USDT_DAI_PATH = abi.encodePacked(USDC, uint24(100), USDT, uint24(100), DAI);
         checkStableSwap(USDC, DAI, USDC_USDT_DAI_PATH);
     }
-
-    function testSwapInvalidPath() public {
-        bytes memory USDC_USDT_DAI_PATH = abi.encodePacked(USDC, uint24(100), USDT, uint24(100), DAI);
-
-        vm.expectRevert("SwapperCalleeUniV3/invalid-path");
-        this.checkStableSwap(DAI, USDC, USDC_USDT_DAI_PATH);
-    }
 }


### PR DESCRIPTION
Remove necessary path validation checks from callee. These checks were only meant to provide more explicit revert reasons for a subset of (common) path misconfigurations and were not meant to catch all possible incorrect path arrays. Since the "Swapper/too-few-dst-received" check already protects against path misconfiguration, we are removing the callee checks to avoid confusion. This PR closes #52.