### PR TITLE
Minor gas optimisations

### DIFF
--- a/src/AllocatorVault.sol
+++ b/src/AllocatorVault.sol
@@ -182,7 +182,7 @@ contract AllocatorVault {
         uint256 rate = jug.drip(ilk);
         uint256 dart = wad * RAY / rate;
         require(dart <= uint256(type(int256).max), "AllocatorVault/overflow");
-        vat.frob(ilk, address(this), address(this), address(this), 0, -int256(dart));
+        vat.frob(ilk, address(this), address(0), address(this), 0, -int256(dart));
         emit Wipe(msg.sender, wad);
     }
 }

--- a/src/funnels/DepositorUniV3.sol
+++ b/src/funnels/DepositorUniV3.sol
@@ -229,8 +229,7 @@ contract DepositorUniV3 {
             // Reset batch
             limit.due0 = limits[p.gem0][p.gem1][p.fee].cap0;
             limit.due1 = limits[p.gem0][p.gem1][p.fee].cap1;
-            limit.era  = limits[p.gem0][p.gem1][p.fee].era;
-            limit.end  = uint32(block.timestamp) + limit.era;
+            limit.end  = uint32(block.timestamp) + limits[p.gem0][p.gem1][p.fee].era;
         }
 
         UniV3PoolLike pool = _getPool(p.gem0, p.gem1, p.fee);
@@ -271,8 +270,7 @@ contract DepositorUniV3 {
             // Reset batch
             limit.due0 = limits[p.gem0][p.gem1][p.fee].cap0;
             limit.due1 = limits[p.gem0][p.gem1][p.fee].cap1;
-            limit.era  = limits[p.gem0][p.gem1][p.fee].era;
-            limit.end  = uint32(block.timestamp) + limit.era;
+            limit.end  = uint32(block.timestamp) + limits[p.gem0][p.gem1][p.fee].era;
         }
 
         UniV3PoolLike pool = _getPool(p.gem0, p.gem1, p.fee);


### PR DESCRIPTION
Under the chosen optimisation config (`optimizer = true, optimizer_runs = 200`), this gives the following gas savings:
- usage of `address(0)` in `wipe()`: 0 gas savings (but still good to align the `frob` parameters with the `frob` params used in `draw()`)
- avoiding `mstore` of `limit.era`: 24 gas savings